### PR TITLE
Fix bias marking

### DIFF
--- a/ithkuil/morphology/words/formative.py
+++ b/ithkuil/morphology/words/formative.py
@@ -117,8 +117,9 @@ class Formative(Word):
             if slot not in self.slots:
                 return
             vals = values(slot)
-            if slot == 'Cb' and 'Cb+' in self.slots:
-                vals['Bias'] += '+' if self.slots['Cb+'] else ''
+            if slot == 'Cb' and self.slots.get('Cb+'):
+                vals['Bias']['name'] += '+'
+                vals['Bias']['code'] += '+'
             desc.update(vals) 
 
         def suffix(suf):

--- a/ithkuil/morphology/words/personal.py
+++ b/ithkuil/morphology/words/personal.py
@@ -145,8 +145,9 @@ class PersonalAdjunct(Word):
                 self.spoof_defaults = True
                 vals = values(*slots)
                 self.spoof_defaults = False
-            if 'Bias' in vals and 'Cb+' in self.slots:
-                vals['Bias']['name'] += '+' if self.slots['Cb+'] else ''
+            if 'Bias' in vals and self.slots.get('Cb+'):
+                vals['Bias']['code'] += '+'
+                vals['Bias']['name'] += '+'
             desc.update(vals)
             
         def add_dict(slots):

--- a/ithkuil/morphology/words/verbal.py
+++ b/ithkuil/morphology/words/verbal.py
@@ -66,8 +66,9 @@ class VerbalAdjunct(Word):
             vals = values(slot)
             if 'Modality' in vals and vals['Modality']['code'] == '(NO-MOD)':
                 del vals['Modality']
-            if slot == 'Cb' and 'Cb+' in self.slots:
-                vals['Bias'] += '+' if self.slots['Cb+'] else ''
+            if slot == 'Cb' and self.slots.get('Cb+'):
+                vals['Bias']['code'] += '+'
+                vals['Bias']['name'] += '+'
             if 'Aspect' in vals and 'Aspect' in desc:
                 vals['Aspect 2'] = vals['Aspect']
                 del vals['Aspect']


### PR DESCRIPTION
Currently, intensive-form biases can crash the parser:

```pycon
>>> from ithkuil.morphology.words import Factory
>>> Factory.parseWord("qal'nn").fullDescription()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/lynn/code/ithkuil-bugfix/ithkuil/morphology/words/formative.py", line 131, in fullDescription
    self.fillResult(add, suffix)
  File "/home/lynn/code/ithkuil-bugfix/ithkuil/morphology/words/formative.py", line 71, in fillResult
    add('Cb')
  File "/home/lynn/code/ithkuil-bugfix/ithkuil/morphology/words/formative.py", line 121, in add
    vals['Bias'] += '+' if self.slots['Cb+'] else ''
TypeError: unsupported operand type(s) for +=: 'dict' and 'str'
```

The `+` should probably get appended to both the `name` and the `code` of the Bias record. This PR supplies a fix.